### PR TITLE
feat: handle crawlers in the legacy app

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -18,6 +18,9 @@ server {
   }
 
   location ~ ^/(assets|profile|contacts|callouts|join|auth|admin|_theme) {
+    if ($http_user_agent ~* "linkedinbot|googlebot|yahoo|bingbot|baiduspider|yandex|yeti|yodaobot|gigabot|ia_archiver|facebookexternalhit|twitterbot|developers\.google\.com") {
+        proxy_pass ${LEGACY_APP_URL}/share?uri=$request_uri;
+    }
     proxy_pass ${FRONTEND_APP_URL};
   }
 


### PR DESCRIPTION
Adds a special condition for crawlers that directs them to the legacy app rather than the new frontend, which then sends them back appropriate metadata (share meta tags basically).

Related change to handle rendering the metadata is https://github.com/beabee-communityrm/beabee/pull/145